### PR TITLE
Move production BABEL_ENV to npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Building Chrome apps and cross-browser extensions with Redux and Webpack.",
   "scripts": {
     "start": "gulp",
-    "build:extension": "gulp build:extension",
-    "build:app": "gulp build:app",
+    "build:extension": "BABEL_ENV=production gulp build:extension",
+    "build:app": "BABEL_ENV=production gulp build:app",
     "compress:extension": "npm run build:extension && gulp compress:extension",
     "compress:app": "npm run build:app && gulp compress:app",
     "clean": "rm -rf build/ && rm -rf dev/",

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,8 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
 
-process.env.BABEL_ENV = 'production';
-
 export default {
   entry: {
     background: [ path.join(__dirname, '../src/browser/extension/background/index') ],


### PR DESCRIPTION
Sorry, this [commit](https://github.com/zalmoxisus/browser-redux/commit/bc6906d9fb29dfa4707da91f72464a59b0fa436d) is wrong, because it will overwrite dev mode. (gulpfile.babel.js)

my bad :/